### PR TITLE
Change "find_max_brightness" to use current color for default ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.8 (Not yet released)
+
+ * Changed default in ``Illuminate.find_max_brightness`` to use current color for the ratio.
+
 ## 0.6.7 (2021/07/19)
 
  * Minimize occurance of spurious failures upon opening the LED boards for the

--- a/pyilluminate/illuminate.py
+++ b/pyilluminate/illuminate.py
@@ -455,7 +455,7 @@ class Illuminate:
             # Attempt to open the serial board
             try:
                 self._open()
-            except Exception as e:
+            except Exception:
                 pass
 
             # Check to see if it worked or not.
@@ -913,6 +913,22 @@ class Illuminate:
         # Cache the color for future use
         self._color = c
         # man, mypy is annoying.... i can't get typing for this one to work
+
+    @property
+    def color_850_ir(self):
+        return self.color[2]
+
+    @color_850_ir.setter
+    def color_850_ir(self, value):
+        self.color = (0, 0, value)
+
+    @property
+    def color_940_ir(self):
+        return sum(self.color[:2]) / 2
+
+    @color_940_ir.setter
+    def color_940_ir(self, value):
+        self.color = (value, value, 0)
 
     @property
     def maximum_current(self):

--- a/pyilluminate/illuminate.py
+++ b/pyilluminate/illuminate.py
@@ -264,7 +264,6 @@ class Illuminate:
         self._led_state = None
         self._led_cache = []
         self._maximum_current = maximum_current
-        self._led_current_amps = None
 
         # Create default values for device parameters
         self._color = (0, 0, 0)
@@ -751,9 +750,6 @@ class Illuminate:
     @property
     def led_current_amps(self):
         """Maximum current in amps per LED channel."""
-        if self._led_current_amps is not None:
-            return self._led_current_amps
-
         result = self._ask_list("getLedCurrentAmps")
         try:
             self._check_output(result)
@@ -761,7 +757,6 @@ class Illuminate:
         except NotImplementedError:
             # Version 1.20.6 has a new command for returning this value
             led_current_amps = 0.02
-        self._led_current_amps = led_current_amps
         return led_current_amps
 
     @property

--- a/pyilluminate/illuminate.py
+++ b/pyilluminate/illuminate.py
@@ -264,6 +264,7 @@ class Illuminate:
         self._led_state = None
         self._led_cache = []
         self._maximum_current = maximum_current
+        self._led_current_amps = None
 
         # Create default values for device parameters
         self._color = (0, 0, 0)
@@ -750,6 +751,9 @@ class Illuminate:
     @property
     def led_current_amps(self):
         """Maximum current in amps per LED channel."""
+        if self._led_current_amps is not None:
+            return self._led_current_amps
+
         result = self._ask_list("getLedCurrentAmps")
         try:
             self._check_output(result)
@@ -757,6 +761,7 @@ class Illuminate:
         except NotImplementedError:
             # Version 1.20.6 has a new command for returning this value
             led_current_amps = 0.02
+        self._led_current_amps = led_current_amps
         return led_current_amps
 
     @property

--- a/pyilluminate/illuminate.py
+++ b/pyilluminate/illuminate.py
@@ -1281,7 +1281,7 @@ class Illuminate:
         self.ask('ssbd.' + str(bitdepth))
         self._sequence_bit_depth = bitdepth
 
-    def find_max_brightness(self, num_leds, color_ratio=(1, 1, 1)):
+    def find_max_brightness(self, num_leds, color_ratio=None):
         """Calculate the maximum brightness for each color channel of an LED
         that won't exceed the TLC's internal current limit.
 
@@ -1299,6 +1299,9 @@ class Illuminate:
             The maximum scaled brightness for each color channel.
         """
         uint16_max = 65535
+
+        if color_ratio is None:
+            color_ratio = self.color
         color_ratio = np.asarray(color_ratio)
         color_ratio = color_ratio / np.sum(color_ratio)
 

--- a/pyilluminate/illuminate.py
+++ b/pyilluminate/illuminate.py
@@ -456,7 +456,7 @@ class Illuminate:
             # Attempt to open the serial board
             try:
                 self._open()
-            except Exception as e:
+            except Exception:
                 pass
 
             # Check to see if it worked or not.

--- a/pyilluminate/illuminate.py
+++ b/pyilluminate/illuminate.py
@@ -456,7 +456,7 @@ class Illuminate:
             # Attempt to open the serial board
             try:
                 self._open()
-            except Exception:
+            except Exception as e:
                 pass
 
             # Check to see if it worked or not.
@@ -918,22 +918,6 @@ class Illuminate:
         # Cache the color for future use
         self._color = c
         # man, mypy is annoying.... i can't get typing for this one to work
-
-    @property
-    def color_850_ir(self):
-        return self.color[2]
-
-    @color_850_ir.setter
-    def color_850_ir(self, value):
-        self.color = (0, 0, value)
-
-    @property
-    def color_940_ir(self):
-        return sum(self.color[:2]) / 2
-
-    @color_940_ir.setter
-    def color_940_ir(self, value):
-        self.color = (value, value, 0)
 
     @property
     def maximum_current(self):

--- a/pyilluminate/tests/test_find_max_brightness.py
+++ b/pyilluminate/tests/test_find_max_brightness.py
@@ -29,7 +29,7 @@ def test_low_value(light):
 
 
 def test_high_value(light):
-    max_brightness = light.find_max_brightness(655)
+    max_brightness = light.find_max_brightness(655, color_ratio=(1, 1, 1))
     goal_brightness = (
         51.90839694656488,
         51.90839694656488,
@@ -48,4 +48,13 @@ def test_ratios(light):
     assert_array_almost_equal(max_brightness, goal_brightness, decimal=5)
 
     max_brightness = light.find_max_brightness(655, (6, 4, 2))
+    assert_array_almost_equal(max_brightness, goal_brightness, decimal=5)
+
+    light.color = (3, 2, 1)
+    max_brightness = light.find_max_brightness(655)
+    goal_brightness = (
+        77.86259541984732,
+        51.90839694656488,
+        25.95419847328244,
+    )
     assert_array_almost_equal(max_brightness, goal_brightness, decimal=5)

--- a/pyilluminate/tests/test_led_color.py
+++ b/pyilluminate/tests/test_led_color.py
@@ -1,23 +1,15 @@
 from pyilluminate import Illuminate
-from pyilluminate.fake_illuminate import FakeIlluminate
 from time import sleep
 import numpy as np
 import pytest
 
+pytestmark = pytest.mark.device
 
-@pytest.fixture(
-    scope='function',
-    params=[
-        pytest.param(True, marks=pytest.mark.device),
-        False
-    ])
-def light(request):
-    if request.param:
-        with Illuminate() as light:
-            yield light
-    else:
-        with FakeIlluminate() as light:
-            yield light
+
+@pytest.fixture(scope='module')
+def light():
+    with Illuminate() as light:
+        yield light
 
 
 def test_single_color(light):
@@ -46,19 +38,3 @@ def test_green_color_numpy(light):
     light.fill_array()
     sleep(1)
     light.clear()
-
-
-def test_ir_colors(light):
-    light.color = (5, 10, 2)
-    assert light.color_940_ir == 7.5  # average of first two values
-    assert light.color_850_ir == 2
-
-    light.color_940_ir = 20
-    assert light.color == (20, 20, 0)
-    assert light.color_940_ir == 20
-    assert light.color_850_ir == 0
-
-    light.color_850_ir = 10
-    assert light.color == (0, 0, 10)
-    assert light.color_940_ir == 0
-    assert light.color_850_ir == 10

--- a/pyilluminate/tests/test_led_color.py
+++ b/pyilluminate/tests/test_led_color.py
@@ -1,15 +1,23 @@
 from pyilluminate import Illuminate
+from pyilluminate.fake_illuminate import FakeIlluminate
 from time import sleep
 import numpy as np
 import pytest
 
-pytestmark = pytest.mark.device
 
-
-@pytest.fixture(scope='module')
-def light():
-    with Illuminate() as light:
-        yield light
+@pytest.fixture(
+    scope='function',
+    params=[
+        pytest.param(True, marks=pytest.mark.device),
+        False
+    ])
+def light(request):
+    if request.param:
+        with Illuminate() as light:
+            yield light
+    else:
+        with FakeIlluminate() as light:
+            yield light
 
 
 def test_single_color(light):
@@ -38,3 +46,19 @@ def test_green_color_numpy(light):
     light.fill_array()
     sleep(1)
     light.clear()
+
+
+def test_ir_colors(light):
+    light.color = (5, 10, 2)
+    assert light.color_940_ir == 7.5  # average of first two values
+    assert light.color_850_ir == 2
+
+    light.color_940_ir = 20
+    assert light.color == (20, 20, 0)
+    assert light.color_940_ir == 20
+    assert light.color_850_ir == 0
+
+    light.color_850_ir = 10
+    assert light.color == (0, 0, 10)
+    assert light.color_940_ir == 0
+    assert light.color_850_ir == 10


### PR DESCRIPTION
This updates the "find_max_brightness" function so it can be used to find the maximum brightness for its current color ratio.

This also caches a value used in max brightness calculation, so the operation can be performed faster. 