### PR TITLE
Remove broken code that never returned the current of the LEDs in AMPs

### DIFF
--- a/pyilluminate/illuminate.py
+++ b/pyilluminate/illuminate.py
@@ -1216,6 +1216,7 @@ class Illuminate:
     def find_max_brightness(self, num_leds, color_ratio=None):
         """Calculate the maximum brightness for each color channel of an LED
         that won't exceed the TLC's internal current limit.
+
         Parameters
         ----------
         num_leds: int
@@ -1223,6 +1224,7 @@ class Illuminate:
         color_ratio: (float, float, float)
             The required ratio for the brightness values
             of each color channel (r, g, b)
+
         Returns
         -------
         brightness: (float, float, float)

--- a/pyilluminate/illuminate.py
+++ b/pyilluminate/illuminate.py
@@ -674,6 +674,11 @@ class Illuminate:
             return ''
 
     @property
+    def led_current_amps(self):
+        """Maximum current in amps per LED channel."""
+        return 0.02
+
+    @property
     def mac_address(self) -> str:
         """MAC Address of the Teansy that drives the LED board."""
         return self._mac_address

--- a/pyilluminate/illuminate.py
+++ b/pyilluminate/illuminate.py
@@ -674,18 +674,6 @@ class Illuminate:
             return ''
 
     @property
-    def led_current_amps(self):
-        """Maximum current in amps per LED channel."""
-        result = self._ask_list("getLedCurrentAmps")
-        try:
-            self._check_output(result)
-            led_current_amps = float(result[0])
-        except NotImplementedError:
-            # Version 1.20.6 has a new command for returning this value
-            led_current_amps = 0.02
-        return led_current_amps
-
-    @property
     def mac_address(self) -> str:
         """MAC Address of the Teansy that drives the LED board."""
         return self._mac_address
@@ -1219,42 +1207,6 @@ class Illuminate:
 
         self.ask('ssbd.' + str(bitdepth))
         self._sequence_bit_depth = bitdepth
-
-    def find_max_brightness(self, num_leds, color_ratio=None):
-        """Calculate the maximum brightness for each color channel of an LED
-        that won't exceed the TLC's internal current limit.
-
-        Parameters
-        ----------
-        num_leds: int
-            The number of LEDs to be illuminated.
-        color_ratio: (float, float, float)
-            The required ratio for the brightness values
-            of each color channel (r, g, b)
-
-        Returns
-        -------
-        brightness: (float, float, float)
-            The maximum scaled brightness for each color channel.
-        """
-        uint16_max = 65535
-
-        if color_ratio is None:
-            color_ratio = self.color
-        color_ratio = np.asarray(color_ratio)
-        color_ratio = color_ratio / np.sum(color_ratio)
-
-        # equation modified from TLC5955 driver
-        total_brightness = (self.maximum_current * uint16_max /
-                            (num_leds * self._scale_factor *
-                             self.led_current_amps))
-
-        max_brightness = total_brightness * color_ratio
-
-        max_one_led_brightness = np.max(max_brightness)
-        if max_one_led_brightness > 255:
-            max_brightness = max_brightness * 255 / max_one_led_brightness
-        return tuple(max_brightness)
 
     def trigger(self, index):
         """Output TTL trigger pulse to camera."""


### PR DESCRIPTION
moved `find_max_brightness` to python-owl in order to be compatible with analog settings\
https://gitlab.com/ramonaoptics/mcam/python-owl/-/issues/783